### PR TITLE
Add UTC offsets, fix set_time() bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ You'll need to install the following libraries from the Adafruit libraries packa
 
 * adafruit_ntp
 
+Also add a `tz_offset` key to your `secrets.py`, specifying your local timezone's offset from UTC in hours, like this:
+```
+secrets = {
+  ...
+  'tz_offset' : 9,  # Tokyo is UTC+9
+  ...
+```
+
 ## NTP
 
 This requests the time from an NTP server and will set time and RTC silently for you, or fail. The code tries again repeatedly until it gets a time. It doesn't ask again.

--- a/code.py
+++ b/code.py
@@ -56,13 +56,14 @@ while not esp.is_connected:
 
 print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
 
+tz_offsecs = secrets.get("tz_offset", 0) * 60 * 60
 # Get NTP time, may make several attempts
 ntp = NTP(esp)
-ntp.set_time()
+ntp.set_time(tz_offsecs)
 while not ntp.valid_time:
     print("time not valid...")
     time.sleep(5)
-    ntp.set_time(60 * 60)
+    ntp.set_time(tz_offsecs)
 
 # Get the RTC time, not NTP updates RTC silently
 rtc = RTC()


### PR DESCRIPTION
This patch supports a `tz_offset` key in `secrets.py`, to support users whose local timezone isn't exactly UTC.

Also fixes a nasty bug that guarantees times are ahead by 1 hour, if the NTP query doesn't succeed the first time for whatever reason.